### PR TITLE
Using project.version instead of upstream version for better Maven compatibility and UNSNAPSHOT support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <upstream.version>36eb0787cc5</upstream.version>
         <upstream.commit>36eb0787cc5dca38f54f10480c5b9efd1ab83229</upstream.commit>
         <upstream.url>https://codeload.github.com/google/blockly/zip/${upstream.commit}</upstream.url>
-        <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
+        <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
     </properties>
 
     <build>


### PR DESCRIPTION
I realised that the POM was using the upstream version (essentially, the github commit ID of the upstream project) instead of the artifact version - this led to issues with other dependency plugins.

Now using the artifact version, I hope it's okay.